### PR TITLE
Fix Pipeline script auto-loading

### DIFF
--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTake(t *testing.T) {
-	l := newTestLimiter(t)
+	l := newTestLimiter(t, true)
 	ctx := context.Background()
 
 	r1, err := l.Take(ctx, "test_id", "req1", redis_rate.ConcurrencyLimit{

--- a/pipeline.go
+++ b/pipeline.go
@@ -104,7 +104,7 @@ func (p *pipeline) exec(ctx context.Context, depth int) error {
 	}
 
 	_, err := pipe.Exec(ctx)
-	if err != nil {
+	if err != nil && !redis.HasErrorPrefix(err, "NOSCRIPT") {
 		return err
 	}
 


### PR DESCRIPTION
Currently there is a bug (tested against Redis 7.2) in the automatic script-loading functionality of Pipelines; if the scripts are not loaded the call to `Exec()` will fail with `NOSCRIPT No matching script. Please use EVAL.`. The code intends to check the results of the individual script-exists commands, but bails before that ever happens due to the error from `Exec()`.

This PR:

1. Updates the tests to unload scripts from Redis during the execution of each test case, and adds a `loadScripts` parameter to `newTestLimiter` so that most test cases can continue to expect scripts to be pre-loaded while `TestAllowMulti` is given a clean Redis instance, with no scripts loaded. This causes `TestAllowMulti` to fail as of 65ac0593da87d6f21c47a1d5bdac58aba5ba1156.
2. Updates the `Exec()` error check to ignore `NOSCRIPT` errors.

This seems to work, but it might be simpler to replace the entire `scriptExistChecks` functionality with a check for a `NOSCRIPT` error.

Note that the "NOSCRIPT" check seems a little janky, but emulates some existing behavior in go-redis [here](https://github.com/redis/go-redis/blob/c3098d5f7eba88330638a8b2b3e23d42cd5c9338/script.go#L68-L74).